### PR TITLE
configure table to sort by aid on load

### DIFF
--- a/src/app/shared/components/Table.tsx
+++ b/src/app/shared/components/Table.tsx
@@ -84,7 +84,7 @@ const Table: React.FC<TableProps> = ({ keyBy, data, dataToHighlight, config, row
     return res;
   };
 
-  const [filterBy, setFilterBy] = useState(4);
+  const [filterBy, setFilterBy] = useState(0);
   const [td, setTd] = useState(updateTableData(data));
   const [tdTmp, setTdTmp] = useState([]);
   const [isSearchActive, setIsSearchActive] = useState(false);


### PR DESCRIPTION
This fixes issue #1 

**Changes:**
Configure table to sort by aid instead of "Minted By" value. This was done by setting the state of the variable `filterBy` to 0. It was previously set to "4", causing the app to sort by "Minted By" on load.

Behavior:

![image](https://github.com/BeamMW/asset-minter-app/assets/17892416/4eee9202-aa9a-4208-bfb6-32f5019096a4)
