### PR TITLE
correctly display  logo url on registration command and add copy button

### DIFF
--- a/src/app/containers/Main/containers/CreatePage/CreatePage.tsx
+++ b/src/app/containers/Main/containers/CreatePage/CreatePage.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { styled } from '@linaria/react';
 import { Button, Window, Input, BackControl } from '@app/shared/components';
-import { css } from '@linaria/core';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import { useFormik } from 'formik';
-import { CreateAsset, UserWithdraw } from '@core/api';
+import { CreateAsset } from '@core/api';
 import { ROUTES } from '@app/shared/constants';
+import CopyIconButton from '@app/shared/components/CopyIconButton';
+import { css } from '@linaria/core';
 
 interface CreateFormData {
   schema: string;
@@ -35,12 +35,6 @@ const Command = styled.div`
   background-color: rgba(0, 246, 210, .1);
   border-radius: 10px;
   margin-bottom: 10px;
-
-  > .text {
-    font-family: 'CourierRegular';
-    margin-top: 30px;
-    word-wrap: break-word;
-  }
 
   > .empty-text {
     font-style: italic;
@@ -119,6 +113,14 @@ const SectionSubTitle = styled.div<{valid?: boolean}>`
   margin-top: 20px;
 `;
 
+
+const CommandText = styled.div`
+  font-family: 'CourierRegular';
+  margin-top: 30px;
+  margin-bottom: 10px;
+  word-wrap: break-word;
+`;
+
 const CreatePage = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [regCommand, setRegCommand] = useState('');
@@ -139,7 +141,7 @@ const CreatePage = () => {
         site_url.length > 0 ? 'OPT_SITE_URL=' + site_url + ';' : ''}${
         pdf_url.length > 0 ? 'OPT_PDF_URL=' + pdf_url + ';' : ''}${
         favicon_url.length > 0 ? 'OPT_FAVICON_URL=' + favicon_url + ';' : ''}${
-        logo_url.length > 0 ? 'OPT_LOGO_URL=' + ratio + ';' : ''}${
+        logo_url.length > 0 ? 'OPT_LOGO_URL=' + logo_url + ';' : ''}${
         color.length > 0 ? 'OPT_COLOR=' + color + ';' : ''}`;
   };
 
@@ -362,7 +364,8 @@ const CreatePage = () => {
             <SectionTitle>REGISTRATION COMMAND</SectionTitle>
             {regCommand.length > 0 ? 
             <>
-              <div className='text'>{regCommand}</div>
+              <CommandText>{regCommand}</CommandText>
+              <CopyIconButton onCopy={() => regCommand} />
               <div className='copy-text'>Copy and paste this command in command line</div>
             </> :
             <div className='empty-text'>Enter asset parameters</div>}

--- a/src/app/shared/components/CopyIconButton.tsx
+++ b/src/app/shared/components/CopyIconButton.tsx
@@ -1,0 +1,30 @@
+import { css } from "@linaria/core";
+import { IconCopyWhite } from "../icons"
+import React from "react";
+import { toast } from "react-toastify";
+
+interface CopyIconButtonProps {
+  onCopy?: any;
+}
+
+const CopyButtonStyles = css`
+  cursor: pointer;
+`;
+
+const CopyIconButton = ({ onCopy }: CopyIconButtonProps) => {
+  const handleClick = () => {
+    const dataToCopy = onCopy();
+    const newElement = document.createElement('textarea');
+
+    newElement.value = dataToCopy;
+    document.body.appendChild(newElement);
+    newElement.select();
+    document.execCommand('copy');
+    document.body.removeChild(newElement);
+    toast('Copied to clipboard');
+  }
+
+  return <IconCopyWhite className={CopyButtonStyles} onClick={handleClick} />
+}
+
+export default CopyIconButton;


### PR DESCRIPTION
This PR fixes issue #2 


Changes:
Adjusted code to correctly display logo URL on registration command component.

Created a new shared component called `CopyIconButton` that can be reused in order to copy content and display toast message on the application.

Evidence:

![image](https://github.com/BeamMW/asset-minter-app/assets/17892416/fd848ff7-e4a8-445e-9434-497e3c68cad8)


